### PR TITLE
feat: convert Tauri's NSWindow to NSPanel to create a spotlight app the correct way!

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 specifiers:
   '@tauri-apps/api': ^1.2.0
@@ -195,6 +195,8 @@ packages:
     resolution: {integrity: sha512-T3Z9oHybU+0vZlY9CiDSJQTD5ZapcW18ZctFMi0MOAl/4BjFF4ul7NVSARLdbGO5vDqy9eQiGTV0LtKfvCYvcg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+    dependencies:
+      '@babel/types': 7.20.7
     dev: true
 
   /@babel/plugin-transform-react-jsx-self/7.18.6_@babel+core@7.20.12:
@@ -258,6 +260,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [arm]
     os: [android]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -266,6 +269,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -274,6 +278,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -282,6 +287,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -290,6 +296,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -298,6 +305,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -306,6 +314,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -314,6 +323,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -322,6 +332,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -330,6 +341,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -338,6 +350,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -346,6 +359,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -354,6 +368,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -362,6 +377,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -370,6 +386,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -378,6 +395,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -386,6 +404,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -394,6 +413,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -402,6 +422,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -410,6 +431,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -418,6 +440,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -426,6 +449,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -477,6 +501,7 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -485,6 +510,7 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -493,6 +519,7 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [linux]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -501,6 +528,7 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -509,6 +537,7 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -517,6 +546,7 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -525,6 +555,7 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -533,6 +564,7 @@ packages:
     engines: {node: '>= 10'}
     cpu: [ia32]
     os: [win32]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -541,6 +573,7 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -711,6 +744,7 @@ packages:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+    requiresBuild: true
     dev: true
     optional: true
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2692,6 +2692,8 @@ dependencies = [
  "core-foundation",
  "core-graphics",
  "objc",
+ "objc-foundation",
+ "objc_id",
  "serde",
  "serde_json",
  "tauri",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tauri-macos-spotlight-app"
 version = "0.0.0"
-description = "A Tauri App"
+description = "A Tauri macOS spotlight app"
 authors = ["Victor Aremu <victor.olorunbunmi@gmail.com>"]
 license = ""
 repository = ""
@@ -23,6 +23,8 @@ core-graphics = {version = "0.22.3"}
 core-foundation = { version = "0.9.3" }
 cocoa = { version = "0.24.1" }
 objc =  { version = "0.2.7" }
+objc_id = {version = "0.1.1" }
+objc-foundation = { version = "0.1.1" }
 
 
 [features]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -9,13 +9,12 @@ fn main() {
     tauri::Builder::default()
         .invoke_handler(tauri::generate_handler![
             spotlight::init_spotlight_window,
+            spotlight::show_spotlight,
             spotlight::hide_spotlight
         ])
         .manage(spotlight::State::default())
         .setup(move |app| {
-            // Set the app's activation poicy to Accessory does the following behaviours:
-            // - Makes the windows of this app appear above full-screen windows of other apps.
-            // - Prevents the app's icon from showing on the dock.
+            // Set activation poicy to Accessory to prevent the app icon from showing on the dock
             app.set_activation_policy(tauri::ActivationPolicy::Accessory);
             Ok(())
         })

--- a/src-tauri/src/spotlight.rs
+++ b/src-tauri/src/spotlight.rs
@@ -1,21 +1,23 @@
 use std::sync::{Mutex, Once};
 
+use objc_id::{Id, ShareId};
 use tauri::{
-    GlobalShortcutManager, Manager, PhysicalPosition, PhysicalSize, Window, WindowEvent, Wry,
+    AppHandle, GlobalShortcutManager, Manager, PhysicalPosition, PhysicalSize, Window, Wry,
 };
 
 use cocoa::{
-    appkit::{
-        CGFloat, NSApplicationActivationOptions, NSMainMenuWindowLevel, NSWindow,
-        NSWindowCollectionBehavior,
-    },
+    appkit::{CGFloat, NSMainMenuWindowLevel, NSWindow, NSWindowCollectionBehavior},
     base::{id, nil, BOOL, NO, YES},
     foundation::{NSPoint, NSRect},
 };
-use objc::{class, msg_send, sel, sel_impl};
-
-#[allow(non_camel_case_types)]
-type pid_t = i32;
+use objc::{
+    class,
+    declare::ClassDecl,
+    msg_send,
+    runtime::{self, Class, Object, Protocol, Sel},
+    sel, sel_impl, Message,
+};
+use objc_foundation::INSObject;
 
 #[link(name = "Foundation", kind = "framework")]
 extern "C" {
@@ -24,7 +26,7 @@ extern "C" {
 
 #[derive(Default)]
 pub struct Store {
-    previous_frontmost_window_pid: Option<pid_t>,
+    panel: Option<ShareId<RawNSPanel>>,
 }
 
 #[derive(Default)]
@@ -71,6 +73,22 @@ macro_rules! get_state {
 }
 
 #[macro_export]
+macro_rules! panel {
+    ($app_handle:expr) => {{
+        let handle = $app_handle.app_handle();
+        let panel = handle
+            .state::<$crate::spotlight::State>()
+            .0
+            .lock()
+            .unwrap()
+            .panel
+            .clone();
+
+        panel.unwrap()
+    }};
+}
+
+#[macro_export]
 macro_rules! nsstring_to_string {
     ($ns_string:expr) => {{
         use objc::{sel, sel_impl};
@@ -92,61 +110,42 @@ macro_rules! nsstring_to_string {
 }
 
 static INIT: Once = Once::new();
+static PANEL_LABEL: &str = "main";
 
 #[tauri::command]
-pub fn init_spotlight_window(window: Window<Wry>) {
+pub fn init_spotlight_window(app_handle: AppHandle<Wry>, window: Window<Wry>) {
     INIT.call_once(|| {
-        register_shortcut(&window);
-        register_spotlight_window_backdrop(&window);
-        set_spotlight_window_collection_behaviour(&window);
-        set_above_main_window_level(&window);
-        show_spotlight(window);
+        set_state!(app_handle, panel, Some(create_spotlight_panel(&window)));
+        register_shortcut(app_handle);
     });
 }
 
-#[tauri::command]
-pub fn show_spotlight(window: Window<Wry>) {
-    set_state!(
-        window.app_handle(),
-        previous_frontmost_window_pid,
-        get_frontmost_app_process_id()
-    );
-    window.set_focus().unwrap();
-}
+fn register_shortcut(app_handle: AppHandle<Wry>) {
+    let mut shortcut_manager = app_handle.global_shortcut_manager();
+    let window = app_handle.get_window(PANEL_LABEL).unwrap();
 
-#[tauri::command]
-pub fn hide_spotlight(window: Window<Wry>) {
-    if window.is_visible().unwrap() {
-        if let Some(pid) = get_state!(window.app_handle(), previous_frontmost_window_pid) {
-            activate_app_with_process_id(pid);
-        }
-        window.hide().unwrap();
-    }
-}
-
-fn register_shortcut(window: &Window<Wry>) {
-    let window = window.to_owned();
-    let mut shortcut_manager = window.app_handle().global_shortcut_manager();
-
+    let panel = panel!(app_handle);
     shortcut_manager
         .register("Cmd+k", move || {
             position_window_at_the_center_of_the_monitor_with_cursor(&window);
-            if window.is_visible().unwrap() {
-                hide_spotlight(window.clone());
+
+            if panel.is_visible() {
+                hide_spotlight(window.app_handle());
             } else {
-                show_spotlight(window.clone());
+                show_spotlight(window.app_handle());
             };
         })
         .unwrap();
 }
 
-fn register_spotlight_window_backdrop(window: &Window<Wry>) {
-    let w = window.to_owned();
-    window.on_window_event(move |event| {
-        if let WindowEvent::Focused(false) = event {
-            w.hide().unwrap();
-        }
-    });
+#[tauri::command]
+pub fn show_spotlight(app_handle: AppHandle<Wry>) {
+    panel!(app_handle).show();
+}
+
+#[tauri::command]
+pub fn hide_spotlight(app_handle: AppHandle<Wry>) {
+    panel!(app_handle).order_out(None);
 }
 
 /// Positions a given window at the center of the monitor with cursor
@@ -166,25 +165,6 @@ fn position_window_at_the_center_of_the_monitor_with_cursor(window: &Window<Wry>
         };
         let _: () = unsafe { msg_send![handle, setFrame: rect display: YES] };
     }
-}
-
-/// Set the behaviours that makes the window appear on all worksapces
-fn set_spotlight_window_collection_behaviour(window: &Window<Wry>) {
-    let handle: id = window.ns_window().unwrap() as _;
-    unsafe {
-        handle.setCollectionBehavior_(
-            NSWindowCollectionBehavior::NSWindowCollectionBehaviorCanJoinAllSpaces
-                | NSWindowCollectionBehavior::NSWindowCollectionBehaviorStationary
-                | NSWindowCollectionBehavior::NSWindowCollectionBehaviorFullScreenPrimary
-                | NSWindowCollectionBehavior::NSWindowCollectionBehaviorIgnoresCycle,
-        );
-    };
-}
-
-/// Set the window above main menu level
-fn set_above_main_window_level(window: &Window<Wry>) {
-    let handle: id = window.ns_window().unwrap() as _;
-    unsafe { handle.setLevel_((NSMainMenuWindowLevel + 2).into()) };
 }
 
 struct Monitor {
@@ -241,26 +221,208 @@ fn get_monitor_with_cursor() -> Option<Monitor> {
     })
 }
 
-/// Gets the process ID of the frontmost application
-fn get_frontmost_app_process_id() -> Option<pid_t> {
-    let shared_workspace: id = unsafe { msg_send![class!(NSWorkspace), sharedWorkspace] };
-    let frontmost_app: id = unsafe { msg_send![shared_workspace, frontmostApplication] };
-    Some(unsafe { msg_send![frontmost_app, processIdentifier] })
+extern "C" {
+    pub fn object_setClass(obj: id, cls: id) -> id;
 }
 
-/// Activates an application with a given process ID
-fn activate_app_with_process_id(process_id: pid_t) {
-    let app: id = unsafe {
-        msg_send![
-            class!(NSRunningApplication),
-            runningApplicationWithProcessIdentifier: process_id
-        ]
-    };
-    unsafe {
-        let _: () = msg_send![
-            app,
-            activateWithOptions:
-                NSApplicationActivationOptions::NSApplicationActivateIgnoringOtherApps
-        ];
-    };
+#[allow(non_upper_case_globals)]
+const NSWindowStyleMaskNonActivatingPanel: i32 = 1 << 7;
+
+const CLS_NAME: &str = "RawNSPanel";
+
+pub struct RawNSPanel;
+
+impl RawNSPanel {
+    fn get_class() -> &'static Class {
+        Class::get(CLS_NAME).unwrap_or_else(Self::define_class)
+    }
+
+    fn define_class() -> &'static Class {
+        let mut cls = ClassDecl::new(CLS_NAME, class!(NSPanel))
+            .unwrap_or_else(|| panic!("Unable to register {} class", CLS_NAME));
+
+        unsafe {
+            cls.add_method(
+                sel!(canBecomeKeyWindow),
+                Self::can_become_key_window as extern "C" fn(&Object, Sel) -> BOOL,
+            );
+        }
+
+        cls.register()
+    }
+
+    /// Returns YES to ensure that RawNSPanel can become a key window
+    extern "C" fn can_become_key_window(_: &Object, _: Sel) -> BOOL {
+        YES
+    }
+}
+unsafe impl Message for RawNSPanel {}
+
+impl RawNSPanel {
+    fn show(&self) {
+        self.make_first_responder(Some(self.content_view()));
+        self.order_front_regardless();
+        self.make_key_window();
+    }
+
+    fn is_visible(&self) -> bool {
+        let flag: BOOL = unsafe { msg_send![self, isVisible] };
+        flag == YES
+    }
+
+    fn make_key_window(&self) {
+        let _: () = unsafe { msg_send![self, makeKeyWindow] };
+    }
+
+    fn order_front_regardless(&self) {
+        let _: () = unsafe { msg_send![self, orderFrontRegardless] };
+    }
+
+    fn order_out(&self, sender: Option<id>) {
+        let _: () = unsafe { msg_send![self, orderOut: sender.unwrap_or(nil)] };
+    }
+
+    fn content_view(&self) -> id {
+        unsafe { msg_send![self, contentView] }
+    }
+
+    fn make_first_responder(&self, sender: Option<id>) {
+        if let Some(responder) = sender {
+            let _: () = unsafe { msg_send![self, makeFirstResponder: responder] };
+        } else {
+            let _: () = unsafe { msg_send![self, makeFirstResponder: self] };
+        }
+    }
+
+    fn set_level(&self, level: i32) {
+        let _: () = unsafe { msg_send![self, setLevel: level] };
+    }
+
+    fn set_style_mask(&self, style_mask: i32) {
+        let _: () = unsafe { msg_send![self, setStyleMask: style_mask] };
+    }
+
+    fn set_collection_behaviour(&self, behaviour: NSWindowCollectionBehavior) {
+        let _: () = unsafe { msg_send![self, setCollectionBehavior: behaviour] };
+    }
+
+    fn set_delegate(&self, delegate: Option<Id<RawNSPanelDelegate>>) {
+        if let Some(del) = delegate {
+            let _: () = unsafe { msg_send![self, setDelegate: del] };
+        } else {
+            let _: () = unsafe { msg_send![self, setDelegate: self] };
+        }
+    }
+
+    /// Create an NSPanel from Tauri's NSWindow
+    fn from(ns_window: id) -> Id<Self> {
+        let ns_panel: id = unsafe { msg_send![Self::class(), class] };
+        unsafe {
+            object_setClass(ns_window, ns_panel);
+            Id::from_retained_ptr(ns_window as *mut Self)
+        }
+    }
+}
+
+impl INSObject for RawNSPanel {
+    fn class() -> &'static runtime::Class {
+        RawNSPanel::get_class()
+    }
+}
+
+#[allow(dead_code)]
+const DELEGATE_CLS_NAME: &str = "RawNSPanelDelegate";
+
+#[allow(dead_code)]
+struct RawNSPanelDelegate {}
+
+impl RawNSPanelDelegate {
+    #[allow(dead_code)]
+    fn get_class() -> &'static Class {
+        Class::get(DELEGATE_CLS_NAME).unwrap_or_else(Self::define_class)
+    }
+
+    #[allow(dead_code)]
+    fn define_class() -> &'static Class {
+        let mut cls = ClassDecl::new(DELEGATE_CLS_NAME, class!(NSObject))
+            .unwrap_or_else(|| panic!("Unable to register {} class", DELEGATE_CLS_NAME));
+
+        cls.add_protocol(
+            Protocol::get("NSWindowDelegate").expect("Failed to get NSWindowDelegate protocol"),
+        );
+
+        unsafe {
+            cls.add_ivar::<id>("panel");
+
+            cls.add_method(
+                sel!(setPanel:),
+                Self::set_panel as extern "C" fn(&mut Object, Sel, id),
+            );
+
+            cls.add_method(
+                sel!(windowDidBecomeKey:),
+                Self::window_did_become_key as extern "C" fn(&Object, Sel, id),
+            );
+
+            cls.add_method(
+                sel!(windowDidResignKey:),
+                Self::window_did_resign_key as extern "C" fn(&Object, Sel, id),
+            );
+        }
+
+        cls.register()
+    }
+
+    extern "C" fn set_panel(this: &mut Object, _: Sel, panel: id) {
+        unsafe { this.set_ivar("panel", panel) };
+    }
+
+    extern "C" fn window_did_become_key(_: &Object, _: Sel, _: id) {}
+
+    /// Hide panel when it's no longer the key window
+    extern "C" fn window_did_resign_key(this: &Object, _: Sel, _: id) {
+        let panel: id = unsafe { *this.get_ivar("panel") };
+        let _: () = unsafe { msg_send![panel, orderOut: nil] };
+    }
+}
+
+unsafe impl Message for RawNSPanelDelegate {}
+
+impl INSObject for RawNSPanelDelegate {
+    fn class() -> &'static runtime::Class {
+        Self::get_class()
+    }
+}
+
+impl RawNSPanelDelegate {
+    pub fn set_panel_(&self, panel: ShareId<RawNSPanel>) {
+        let _: () = unsafe { msg_send![self, setPanel: panel] };
+    }
+}
+
+fn create_spotlight_panel(window: &Window<Wry>) -> ShareId<RawNSPanel> {
+    // Convert NSWindow Object to NSPanel
+    let handle: id = window.ns_window().unwrap() as _;
+    let panel = RawNSPanel::from(handle);
+    let panel = panel.share();
+
+    // Set panel above the main menu window level
+    panel.set_level(NSMainMenuWindowLevel + 1);
+
+    // Ensure that the panel can display over the top of fullscreen apps
+    panel.set_collection_behaviour(
+        NSWindowCollectionBehavior::NSWindowCollectionBehaviorTransient
+            | NSWindowCollectionBehavior::NSWindowCollectionBehaviorMoveToActiveSpace
+            | NSWindowCollectionBehavior::NSWindowCollectionBehaviorFullScreenAuxiliary,
+    );
+
+    // Ensures panel does not activate
+    panel.set_style_mask(NSWindowStyleMaskNonActivatingPanel);
+
+    // Setup delegate for an NSPanel to listen for window resign key and hide the panel
+    let delegate = RawNSPanelDelegate::new();
+    delegate.set_panel_(panel.clone());
+    panel.set_delegate(Some(delegate));
+
+    panel
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -28,7 +28,7 @@
         "icons/icon.icns",
         "icons/icon.ico"
       ],
-      "identifier": "com.tauri.dev",
+      "identifier": "com.tauri.spotlight",
       "longDescription": "",
       "macOS": {
         "entitlements": null,
@@ -55,14 +55,11 @@
     "windows": [
       {
         "fullscreen": false,
-        "height": 200,
-        "resizable": true,
-        "title": "tauri-macos-spotlight-app",
+        "height": 250,
         "width": 800,
         "resizable": false,
         "decorations": false,
         "center": true,
-        "alwaysOnTop": true,
         "visible": false
       }
     ]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,16 +8,22 @@ function App() {
     invoke("init_spotlight_window");
   }, []);
 
-  useEffect(() => { }, []);
-
   return (
     <div className="container">
-      <h1>Tauri MacOS Spotlight App</h1>
-      <p>
+      <h2>Tauri MacOS Spotlight App</h2>
+      <p style={{ margin: 0 }}>
         Press <kbd>Cmd</kbd>+<kbd>k</kbd> to toggle the spotlight window,
         <br />
         or press <kbd>Esc</kbd> to hide window.
       </p>
+      <form style={{ margin: "10px 0" }}>
+        <input type="text" name="text" placeholder="Search..." />
+      </form>
+      <small>
+        This <mark>NSWindow</mark> was converted to <mark>NSPanel</mark> at
+        runtime.
+      </small>
+      <br />
     </div>
   );
 }


### PR DESCRIPTION
Although the current implementation on our main branch for displaying NSWindow over full-screen apps has been effective, we encountered a setback in the Ventura release due to Apple blocking our workaround. After extensive experimentation over the past week, I have discovered a technical solution: creating an `NSPanel` from a Tauri `NSWindow`. By implementing this approach, we can make the spotlight window as intended without using any workarounds or hacks.


## Demo
![Screen Recording 2023-03-05 at 14 35 57](https://user-images.githubusercontent.com/13041443/222964588-be93bd0e-a121-4b55-9268-319c42980288.gif)

